### PR TITLE
Fix kernel 5.4(+) date-time compilation errors on older distributions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ EXTRA_CFLAGS += -Wno-unused-label
 EXTRA_CFLAGS += -Wno-unused-parameter
 EXTRA_CFLAGS += -Wno-unused-function
 EXTRA_CFLAGS += -Wno-unused
+EXTRA_CFLAGS += -Wno-error=date-time # Fixes the compile error on Linux 5.4 and later
 #EXTRA_CFLAGS += -Wno-uninitialized
 
 GCC_VER_49 := $(shell echo `$(CC) -dumpversion | cut -f1-2 -d.` \>= 4.9 | bc )


### PR DESCRIPTION
core/rtw_debug.c:45:44: error: macro "__TIME__" might prevent reproducible builds [-Werror=date-time]
Added -Wno-error=date-time to the CFLAGS
