### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This driver is based on the (latest) official Realtek v5.2.19.1 driver with fixe
 
 Make sure you have headers, build, dkms and git packages installed.
 
+#### Debian-based Linux distributions :
 Check:
 
 ```
@@ -16,6 +17,13 @@ Install if necessary:
 ```
 sudo apt -y install linux-headers-generic build-essential dkms git
 ```
+
+#### Arch-based Linux distributions :
+Install :
+```
+sudo pacman -S linux-headers base-devel dkms git
+```
+
 ### Automated install 
 
 Run from driver directory:


### PR DESCRIPTION
Adding instructions for Arch-based distributions.
linux-headers is linux-headers-generic
base-devel is build-essential