### PR TITLE
Fix build failure due to redefition of local sha256 data types and fu…

### DIFF
--- a/core/crypto/sha256-internal.c
+++ b/core/crypto/sha256-internal.c
@@ -26,17 +26,17 @@
 int sha256_vector(size_t num_elem, const u8 *addr[], const size_t *len,
 		  u8 *mac)
 {
-	struct sha256_state ctx;
+	struct rtl_sha256_state ctx;
 	size_t i;
 
 	if (TEST_FAIL())
 		return -1;
 
-	sha256_init(&ctx);
+	rtl_sha256_init(&ctx);
 	for (i = 0; i < num_elem; i++)
-		if (sha256_process(&ctx, addr[i], len[i]))
+		if (rtl_sha256_process(&ctx, addr[i], len[i]))
 			return -1;
-	if (sha256_done(&ctx, mac))
+	if (rtl_sha256_done(&ctx, mac))
 		return -1;
 	return 0;
 }
@@ -82,7 +82,7 @@ static const unsigned long K[64] = {
 #endif
 
 /* compress 512-bits */
-static int sha256_compress(struct sha256_state *md, unsigned char *buf)
+static int sha256_compress(struct rtl_sha256_state *md, unsigned char *buf)
 {
 	u32 S[8], W[64], t0, t1;
 	u32 t;
@@ -125,7 +125,7 @@ static int sha256_compress(struct sha256_state *md, unsigned char *buf)
 
 
 /* Initialize the hash state */
-void sha256_init(struct sha256_state *md)
+void rtl_sha256_init(struct rtl_sha256_state *md)
 {
 	md->curlen = 0;
 	md->length = 0;
@@ -146,7 +146,7 @@ void sha256_init(struct sha256_state *md)
    @param inlen  The length of the data (octets)
    @return CRYPT_OK if successful
 */
-int sha256_process(struct sha256_state *md, const unsigned char *in,
+int rtl_sha256_process(struct rtl_sha256_state *md, const unsigned char *in,
 		   unsigned long inlen)
 {
 	unsigned long n;
@@ -186,7 +186,7 @@ int sha256_process(struct sha256_state *md, const unsigned char *in,
    @param out [out] The destination of the hash (32 bytes)
    @return CRYPT_OK if successful
 */
-int sha256_done(struct sha256_state *md, unsigned char *out)
+int rtl_sha256_done(struct rtl_sha256_state *md, unsigned char *out)
 {
 	int i;
 

--- a/core/crypto/sha256_i.h
+++ b/core/crypto/sha256_i.h
@@ -11,15 +11,15 @@
 
 #define SHA256_BLOCK_SIZE 64
 
-struct sha256_state {
+struct rtl_sha256_state {
 	u64 length;
 	u32 state[8], curlen;
 	u8 buf[SHA256_BLOCK_SIZE];
 };
 
-void sha256_init(struct sha256_state *md);
-int sha256_process(struct sha256_state *md, const unsigned char *in,
+void rtl_sha256_init(struct rtl_sha256_state *md);
+int rtl_sha256_process(struct rtl_sha256_state *md, const unsigned char *in,
 		   unsigned long inlen);
-int sha256_done(struct sha256_state *md, unsigned char *out);
+int rtl_sha256_done(struct rtl_sha256_state *md, unsigned char *out);
 
 #endif /* SHA256_I_H */


### PR DESCRIPTION
…nctions

Linux provides sha256_init() and 'struct sha256_state' in file include/crypto/sha2.h so this leads to a build failure due to redefinition. To avoid this let's prepend to all local exposed functions and data types rtl_. sha256_process() and sha256_done() are not required to be renamed but let's change them for consistency.

Signed-off-by: Giulio Benetti <giulio.benetti@benettiengineering.com>