### PR TITLE
Add Raspberry Pi deps to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Also, make sure you have headers, build, dkms and git packages installed.
 
 ```sudo zypper install -t pattern devel_C_C++ && sudo zypper install dkms git```
 
+##### Raspberry Pi:
+
+```sudo apt-get install git raspberrypi-kernel-headers build-essential dkms git```
+
+Also set `CONFIG_PLATFORM_I386_PC = n` and `CONFIG_PLATFORM_ARM_RPI = y` in the `Makefile`.
+
 ### Automated (re)install 
 
 Run from driver directory:


### PR DESCRIPTION
These are the deps and variables needed on a Raspberry Pi.

I took these commands from https://github.com/Mange/rtl8192eu-linux-driver?tab=readme-ov-file#building-and-installing-using-dkms and tested them on a Raspberry Pi Zero (the Raspberry Pi 4 already has the drivers) with a TP-Link TL-WN823N N300.
On a Raspberry Pi 4 the dongle seems to work out of the box, but on a Raspberry 0 it detected a new USB device in `dmesg` but no `wlan1` showed up (`wlan0` is the integrated one).  After installing the drivers the `wlan1` showed up.

This is the full procedure I followed to install the drivers on a Raspberry 0:
```sh
sudo apt-get install git raspberrypi-kernel-headers build-essential dkms
git clone https://github.com/clnhub/rtl8192eu-linux
cd rtl8192eu-linux/
vim Makefile  # update these two vars
    CONFIG_PLATFORM_I386_PC = n
    ...
    CONFIG_PLATFORM_ARM_RPI = y

./install_wifi.sh
```