### PR TITLE
Fix cfg80211 set_monitor_channel for Linux 6.12

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -6894,7 +6894,7 @@ static void rtw_get_chbwoff_from_cfg80211_chan_def(
 
 static int cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
-  #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0))
+  #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 101))
         , struct net_device *netdev
   #endif
         , struct cfg80211_chan_def *chandef

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -6894,7 +6894,7 @@ static void rtw_get_chbwoff_from_cfg80211_chan_def(
 
 static int cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
-  #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
+  #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0))
         , struct net_device *netdev
   #endif
         , struct cfg80211_chan_def *chandef


### PR DESCRIPTION
The rtl8192eu driver currently adds the net_device argument to set_monitor_channel only for Linux 6.13 and later.

Linux 6.12 already uses the updated callback signature, causing the driver to fail to build with:

error: initialization of ... set_monitor_channel ... from incompatible pointer type

This changes the version check from 6.13.0 to 6.12.0.

Tested successfully on Debian 13 with kernel 6.12.107+deb13-amd64 and a TP-Link TL-WN823N v2/v3 (RTL8192EU).

DKMS compilation, installation and module loading were successful.